### PR TITLE
Update cli.py

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,11 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
+# pull request ckrams-patch-1
+# fix issues when during visting see non string valued key
+        if isinstance(obj, str) and key in obj:
+# end fix
+# end pull request changes for ckrams-patch-1
             obj[key] = replace_value
         return obj
 


### PR DESCRIPTION
Issue:
Failed to apply override scenarios.*default-address=https://uxrhp-cardsvc-perf-app.azurewebsites.net
ERROR: TypeError: argument of type 'bool' is not iterable

above fix will take care of multi overrides when visitor comes non string values as keys

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
