### PR TITLE
Update cli.py

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,8 +493,11 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
-            obj[key] = replace_value
+# pull request ckrams-default-overrides-fix
+# fix issues when during visting see non string valued key
+        if isinstance(obj, str) and key in obj:
+# end fix
+# end pull request changes for ckrams-default-overrides-fix
         return obj
 
     def __apply_single_override(self, dest, name, value):


### PR DESCRIPTION
Issue:
Failed to apply override scenarios.*default-address=https://uxrhp-cardsvc-perf-app.azurewebsites.net
ERROR: TypeError: argument of type 'bool' is not iterable

above fix will take care of multi overrides when visitor comes non string values as keys

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
