### PR TITLE
Fix :  TypeError: argument of type 'int' or 'bool' is not iterable wh…

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
+        if isinstance(obj,dict) and key in obj:
             obj[key] = replace_value
         return obj
 


### PR DESCRIPTION
…en applying scenarios.*default-address overrides

Python 3.x reveals this issue and we will be unable to provide dynamic overrides via scenarios.*default-address. 
Following errors reported without above fix
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 254, in perform
    self.__configure(configs)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 179, in __configure
    overrider.apply_overrides(self.options.option, self.engine.config)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 480, in apply_overrides
    self.__apply_single_override(dest, name, value)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 528, in __apply_single_override
    return self.__apply_mult_override(pointer, parts[-1][1:], value)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 495, in __apply_mult_override
    obj[k] = self.__apply_mult_override(v, key, replace_value)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 495, in __apply_mult_override
    obj[k] = self.__apply_mult_override(v, key, replace_value)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 492, in __apply_mult_override
    i = self.__apply_mult_override(i, key, replace_value)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 495, in __apply_mult_override
    obj[k] = self.__apply_mult_override(v, key, replace_value)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 492, in __apply_mult_override
    i = self.__apply_mult_override(i, key, replace_value)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 495, in __apply_mult_override
    obj[k] = self.__apply_mult_override(v, key, replace_value)
  File "/usr/local/Cellar/bzt/1.14.2_1/libexec/lib/python3.7/site-packages/bzt/cli.py", line 496, in __apply_mult_override
    if key in obj:

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
