### PR TITLE
Update cli.py

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isintance(obj, (dict,list)) and key in obj:
+        if isintance(obj, (list,dict)) and key in obj:
             obj[key] = replace_value
         return obj
 


### PR DESCRIPTION
Line 496 revised to if isintance(obj, (dict,list)) and key in obj: to fix the TypeError: argument of type 'int' or 'bool' is not iterable ... in python 3.x

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [X] Description of PR explains the context of change
- [X] Unit tests cover the change, no broken tests 
- [X] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
